### PR TITLE
Support custom suffix formats with %N% placeholder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 jobs:
   test:
     permissions:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
 
 ![Tests](https://github.com/HichemTab-tech/Namecrement/workflows/Test/badge.svg) 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/HichemTab-tech/Namecrement/releases) [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/HichemTab-tech/Namecrement/blob/main/LICENSE)
+[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://github.com/HichemTab-tech/Namecrement/releases) [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/HichemTab-tech/Namecrement/blob/main/LICENSE)
 [![NPM Version](https://img.shields.io/npm/v/namecrement.svg)](https://www.npmjs.com/package/namecrement)
 
 </p>
@@ -57,14 +57,45 @@ console.log(newName); // Output: "file (3)"
 
 ---
 
+## 🧠 Advanced Usage
+
+```ts
+namecrement('file', ['file', 'file -1-', 'file -2-'], ' -%N%-');
+// → 'file -3-'
+```
+
+You can customize how numbers are added by using the `%N%` placeholder in a `suffixFormat`:
+
+| Format Example    | Output             |
+|-------------------|--------------------|
+| `" (%N%)"`        | `file (1)`         |
+| `"-%N%"`          | `file-1`           |
+| `"_v%N%"`         | `file_v1`          |
+| `"<%N%>"`         | `file<1>`          |
+
+---
+
+### ✅ Type-Safe Format
+
+> `suffixFormat` must include the `%N%` placeholder, or the function will throw an error.
+
+This ensures that all generated names include the incremented number in the format you define.
+
+```ts
+namecrement('log', ['log', 'log_1'], '_%N%_'); // → log_2
+```
+
+---
+
 ## 📚 API
 
 ### `namecrement(baseName: string, existingNames: string[]): string`
 
-| Parameter       | Type       | Description                        |
-|-----------------|------------|------------------------------------|
-| `baseName`      | `string`   | The proposed name                  |
-| `existingNames` | `string[]` | The list of names to check against |
+| Parameter       | Type       | Description                                    |
+|-----------------|------------|------------------------------------------------|
+| `baseName`      | `string`   | The proposed name                              |
+| `existingNames` | `string[]` | The list of names to check against             |
+| `suffixFormat`  | `string`   | The format for the incremented name (optional) |
 
 Returns a **unique** name based on the proposed one.
 
@@ -81,6 +112,9 @@ namecrement('image', ['photo', 'image', 'image (1)', 'image (2)']);
 
 namecrement('new', []);
 // → 'new'
+
+namecrement('document', ['document', 'document -1-', 'document (2)'], ' -%N%-');
+// → 'document -2-'
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namecrement",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "A smart JavaScript utility that generates unique incremental names, preventing naming collisions by automatically appending incremental suffixes.",
   "keywords": [

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,34 +1,127 @@
 import { describe, it, expect } from 'vitest';
 import { namecrement } from '../src';
 
-describe('namecrement', () => {
-    it('should return the proposed name if it is unique', () => {
+describe('namecrement (default format)', () => {
+    it('returns the proposed name if it is unique', () => {
         const result = namecrement('file', ['file (1)', 'file (2)']);
         expect(result).toBe('file');
     });
 
-    it('should append " (1)" if the proposed name is already taken', () => {
+    it('appends " (1)" if the proposed name is already taken', () => {
         const result = namecrement('file', ['file']);
         expect(result).toBe('file (1)');
     });
 
-    it('should find the smallest unused suffix', () => {
+    it('finds the smallest unused suffix', () => {
         const result = namecrement('file', ['file', 'file (1)', 'file (2)']);
         expect(result).toBe('file (3)');
     });
 
-    it('should handle names that already have a suffix', () => {
+    it('handles names that already have a suffix', () => {
         const result = namecrement('file (1)', ['file', 'file (1)', 'file (2)']);
         expect(result).toBe('file (3)');
     });
 
-    it('should handle names with gaps in suffixes', () => {
+    it('fills in gaps between suffixes', () => {
         const result = namecrement('file', ['file', 'file (1)', 'file (3)']);
         expect(result).toBe('file (2)');
     });
 
-    it('should escape special characters in the base name', () => {
+    it('escapes special characters in the base name', () => {
         const result = namecrement('file.name', ['file.name', 'file.name (1)']);
         expect(result).toBe('file.name (2)');
+    });
+});
+
+describe('namecrement (custom suffix format)', () => {
+    it('supports dash format', () => {
+        const result = namecrement('file', ['file', 'file -1-', 'file -2-'], ' -%N%-');
+        expect(result).toBe('file -3-');
+    });
+
+    it('supports simple numeric suffix', () => {
+        const result = namecrement('log', ['log', 'log1'], '%N%');
+        expect(result).toBe('log2');
+    });
+
+    it('uses custom suffix even if proposed name has a similar looking suffix', () => {
+        const result = namecrement('item 1', ['item', 'item 1', 'item 2'], ' %N%');
+        expect(result).toBe('item 3');
+    });
+
+    it('returns base name if not in existing list, even with custom format', () => {
+        const result = namecrement('report', ['report -1-'], ' -%N%-');
+        expect(result).toBe('report');
+    });
+
+    it('handles names with special characters and custom format', () => {
+        const result = namecrement('file.name', ['file.name', 'file.name_1_'], '_%N%_');
+        expect(result).toBe('file.name_2_');
+    });
+});
+
+describe('Suffix format validation', () => {
+    it('should allow valid suffix formats with %N%', () => {
+        const result = namecrement('file', [], ' -%N%-');
+        expect(result).toBe('file');
+    });
+
+    it('should throw if suffix format does not include %N%', () => {
+        // @ts-ignore
+        expect(() => namecrement('file', [], ' -X-')).toThrowError(
+            /suffixFormat must include %N%/
+        );
+    });
+});
+
+describe('Edge cases & stress tests', () => {
+    it('handles suffixes with multiple digits', () => {
+        const result = namecrement('file', ['file', 'file (1)', 'file (10)']);
+        expect(result).toBe('file (2)');
+    });
+
+    it('ignores names that don’t match the suffix pattern', () => {
+        const result = namecrement('file', ['file [1]', 'file_1', 'file (x)']);
+        expect(result).toBe('file');
+    });
+
+    it('treats numeric-looking names correctly when not matching suffix format', () => {
+        const result = namecrement('file1', ['file1', 'file1 (1)']);
+        expect(result).toBe('file1 (2)');
+    });
+
+    it('handles special characters like $, [, ], ^, etc.', () => {
+        const result = namecrement('file[1].$^', ['file[1].$^', 'file[1].$^ (1)']);
+        expect(result).toBe('file[1].$^ (2)');
+    });
+
+    it('does not falsely match suffix in middle of name', () => {
+        const result = namecrement('file (1) backup', ['file (1) backup', 'file (1) backup (1)']);
+        expect(result).toBe('file (1) backup (2)');
+    });
+
+    it('treats name with suffix-like part in middle as a distinct base', () => {
+        const result = namecrement('archive (1) final', ['archive (1) final', 'archive (1) final (1)']);
+        expect(result).toBe('archive (1) final (2)');
+    });
+
+    it('fills large gaps correctly', () => {
+        const result = namecrement('file', ['file', 'file (1)', 'file (99)', 'file (100)']);
+        expect(result).toBe('file (2)');
+    });
+
+    it('handles deeply nested suffix correctly', () => {
+        const result = namecrement('file (99)', ['file', 'file (1)', 'file (99)']);
+        expect(result).toBe('file (2)');
+    });
+
+    it('handles complex custom format like <v%N%>', () => {
+        const result = namecrement('version', ['version', 'version<v1>', 'version<v2>'], '<v%N%>');
+        expect(result).toBe('version<v3>');
+    });
+
+    it('handles numeric-only base names', () => {
+        const result = namecrement('2023', ['2023', '2023 (1)', '2023 (2)']);
+        expect(result).toBe('2023 (3)');
     });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -69,7 +69,7 @@ describe('Suffix format validation', () => {
     it('should throw if suffix format does not include %N%', () => {
         // @ts-ignore
         expect(() => namecrement('file', [], ' -X-')).toThrowError(
-            /suffixFormat must include %N%/
+            "suffixFormat must contain \"%N%\""
         );
     });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,15 +2,19 @@ import { defineConfig } from 'vite';
 import banner from 'vite-plugin-banner';
 import { resolve } from 'path';
 import dts from 'vite-plugin-dts';
+import { readFileSync } from 'fs';
 
 
-const bannerContent = `/*!
-* namecrement v1.0.0
+let bannerContent = `/*!
+* namecrement v%VERSION%
 * (c) Hichem Taboukouyout
 * Released under the MIT License.
 * Github: github.com/HichemTab-tech/Namecrement
 */
    `;
+
+const packageJson = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'));
+bannerContent = bannerContent.replace('%VERSION%', packageJson.version);
 
 export default defineConfig({
     build: {


### PR DESCRIPTION
# Description

This PR adds support for custom suffix formats in the `namecrement` function via a new `suffixFormat` parameter.

## What's New

- Added `suffixFormat` parameter to control how suffixes are formatted using `%N%` (default: `" (%N%)"`).
- Type-safe enforcement using a TypeScript template literal (`${string}%N%${string}`).
- Runtime validation: throws if `%N%` is missing.
- Extended test coverage for custom formats, special characters, and edge cases.
- Updated README with advanced usage examples and suffix format customization.

## Examples

```ts
namecrement('file', ['file', 'file -1-', 'file -2-'], ' -%N%-');
// => "file -3-"

namecrement('log', ['log', 'log_v1'], '_v%N%');
// => "log_v2"
```

This makes `namecrement` more flexible and ready for broader use cases like file naming, labeling, versioning, and more.