### PR TITLE
chore: remove unnecessary pnpm cache configuration

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '23.x'  # Ensure you're using Node.js 22.x
-          cache: 'pnpm'
 
       - name: Install pnpm
         run: npm install -g pnpm


### PR DESCRIPTION
Removed the `cache: 'pnpm'` line from the GitHub Actions workflow as it was redundant. The simplification enhances maintainability without affecting the workflow behavior.

- Ensured Node.js setup remains functional without caching.
- Verified compatibility with `pnpm` installation step.